### PR TITLE
Even if GlotPress generated language pack and push to the sites, this…

### DIFF
--- a/wpicp-license.php
+++ b/wpicp-license.php
@@ -38,12 +38,9 @@ function wpicp_license_menu() {
 }
 
 /** Load translation */
-$current_locale = get_locale();
-if (!empty($current_locale)) {
-    $mo_file = dirname(__FILE__) . '/languages/wpicp-license-' . $current_locale . ".mo";
-    if (@file_exists($mo_file) && is_readable($mo_file)) {
-        load_textdomain('wpicp-license', $mo_file);
-    }
+add_action( 'init', 'wpicp_load_textdomain' );
+function wpicp_load_textdomain() {
+	load_plugin_textdomain( 'wpicp-license', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' ); 
 }
 
 // Add settings page and field


### PR DESCRIPTION
`$current_locale = get_locale();
if (!empty($current_locale)) {
    $mo_file = dirname(__FILE__) . '/languages/wpicp-license-' . $current_locale . ".mo";
    if (@file_exists($mo_file) && is_readable($mo_file)) {
        load_textdomain('wpicp-license', $mo_file);
    }
}`

The above code made this plugin cannot read the language pack file generated from GlotPress system, please check them.

After I commented on the above code, this plugin can read the MO file generated from GlotPress. The MO file generated from GlotPress always stores the default system path `/wp-content/languages/plugins`.

Don't only make your plugin read the MO file under `languages` folder on the plugin installation path.